### PR TITLE
add reset of reservation table

### DIFF
--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -1,0 +1,17 @@
+name: Weekly Reset
+
+on:
+  schedule:
+    - cron: "0 0 * * 6"   # every Saturday at 00:00 UTC
+  workflow_dispatch:       # allows manual run
+
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Supabase Function
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            -H "Content-Type: application/json" \
+            "${{ secrets.SUPABASE_URL }}/functions/v1/weekly-reset"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Club de Boxe Reventin – Gestion des Inscriptions
 
-Application web pour gérer les inscriptions aux cours de boxe du **Club de Boxe Reventin**, développée avec **Streamlit** et **SQLAlchemy**.  
+Application web pour gérer les inscriptions aux cours de boxe du **Club de Boxe Reventin**, développée avec **Streamlit**.  
 La base de données est hébergée sur **Supabase (PostgreSQL)**.
 
 ---
@@ -34,8 +34,7 @@ La base de données est hébergée sur **Supabase (PostgreSQL)**.
 ## Prérequis
 
 - Python 3.10 ou supérieur  
-- Streamlit  
-- SQLAlchemy  
+- Streamlit   
 - Pandas  
 - psycopg2-binary (pour la connexion PostgreSQL / Supabase)
 
@@ -88,4 +87,4 @@ engine = create_engine(DATABASE_URL, connect_args={"sslmode": "require"})
 ## Auteur
 Nom : Nguyen Kim
 Projet : Club de Boxe Reventin – Gestion des inscriptions
-Tech Stack : Python, Streamlit, SQLAlchemy, Supabase
+Tech Stack : Python, Streamlit, Supabase

--- a/create_admin.py
+++ b/create_admin.py
@@ -6,7 +6,7 @@ SessionLocal = sessionmaker(bind=engine)
 db = SessionLocal()
 
 # Vérifier si l'admin existe déjà
-admin_email = "nguyen.kim0781@gmail.com"
+admin_email = "admin@example.com"
 admin = db.query(User).filter(User.email == admin_email).first()
 
 if not admin:


### PR DESCRIPTION
# ✨ PR Description: Add Automated Weekly Supabase Table Reset
## Overview

This PR introduces an automated workflow that resets (truncates) the `reservation` table in Supabase every Saturday at midnight (UTC). The reset ensures the table starts fresh each week without manual intervention.

## Changes
### Supabase SQL function
- Added reset_my_table() stored procedure that truncates `reservation` and resets its identity sequence.

### GitHub Actions workflow
- Added .github/workflows/reset.yml:
- Runs on a scheduled cron job (0 0 * * 6 → Saturday 00:00 UTC).
- Calls Supabase via REST API to execute `reset_my_table`().
- Supports manual trigger (workflow_dispatch) for on-demand resets.

Useful for testing or emergency resets outside the scheduled job.

## Secrets & Configuration
Requires two GitHub Actions secrets:
- `SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`


## Motivation
- Keeps the table clean and consistent for weekly data collection/processing.
- Eliminates manual database maintenance.
- Provides both automated and manual reset options.
