### PR TITLE
update code to enable book course on saturday and sunday

### DIFF
--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -15,4 +15,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json" \
-            "${{ secrets.SUPABASE_URL }}/functions/reset_my_table"
+            "${{ secrets.SUPABASE_URL }}/functions/v1/reset_my_table"

--- a/app.py
+++ b/app.py
@@ -73,22 +73,27 @@ def login_user(email, password):
 def is_reservation_allowed(weekday, start_time):
     now = datetime.datetime.now()
     current_weekday = now.weekday()  # 0 = Monday, 6 = Sunday
-    
-    # If course is on a future day, reservation is allowed
+
+    # --- NEXT WEEK SAT & SUN RULE ---
+    # If user selects Saturday (5) or Sunday (6), allow booking for *next* week
+    if weekday in [5, 6]:
+        return True
+
+    # --- SAME WEEK RULES ---
+    # If course is on a future day (Mon–Fri), reservation is allowed
     if weekday > current_weekday:
         return True
-    
+
     # If course is on a past day of the week, reservation is not allowed
     if weekday < current_weekday:
         return False
-    
+
     # If course is today, check if it's at least 1 hour before start time
     hour, minute = map(int, start_time.split(':'))
     course_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-    
-    # Check if current time is at least 1 hour before the course
+
     time_difference = course_time - now
-    return time_difference.total_seconds() >= 3600  # 3600 seconds = 1 hour
+    return time_difference.total_seconds() >= 3600  # must be 1+ hour ahead
 
 
 # -------------------------


### PR DESCRIPTION
# ✨ Summary

This PR updates the course reservation logic to support bookings for next week on Saturday and Sunday, in addition to the existing same-week rules.

# 🔄 Changes

Modified is_reservation_allowed function:
Saturday (5) and Sunday (6): Reservations are always allowed and treated as next week bookings.
Monday–Friday (0–4): Same behavior as before — reservations allowed only if:
- The course is on a future day this week
- The course is today and the booking is made at least 1 hour before the start time.

Past days in the same week remain disallowed.

# ✅ Expected Behavior

Users can now book courses for next week’s Saturday or Sunday.
Users still cannot book past days of the current week.
Same-day bookings are only valid if made at least 1 hour in advance.