### PR TITLE
fix bug on date

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,23 +52,17 @@ def get_weekdays():
 
 def get_current_week_and_year():
     now = datetime.datetime.now()
-    # Determine which week the reservation is for
-    current_week = now.isocalendar()[1]
-    current_year = now.year
 
-    # If today is Saturday or Sunday, book for next week
+    # If today is Saturday or Sunday, shift to next Monday
     if now.weekday() in [5, 6]:
-        week_num = current_week + 1
-        year = current_year
-        # Handle year rollover if week_num exceeds the max week of the year
-        last_week = datetime.date(current_year, 12, 31).isocalendar()[1]
-        if week_num > last_week:
-            week_num = 1
-            year = current_year + 1
+        days_until_monday = 7 - now.weekday()
+        next_monday = now + datetime.timedelta(days=days_until_monday)
+        iso_info = next_monday.isocalendar()
     else:
-        week_num = current_week
-        year = current_year
-    return week_num, year
+        iso_info = now.isocalendar()
+
+    # iso_info = (ISO_year, ISO_week, ISO_weekday)
+    return iso_info[1], iso_info[0]
 
 # -------------------------
 # Users


### PR DESCRIPTION
# 🧩 Fix incorrect week/year rollover on weekends

## Description

This PR fixes a bug in `get_current_week_and_year()` where **Saturday or Sunday** dates incorrectly returned  
`week_num = 1` and `year = next year` (e.g., October 26, 2025 → week 1, 2026).  

The issue occurred because:

- `datetime.date(current_year, 12, 31).isocalendar()[1]` can return **week 1** of the next ISO year.
- The manual rollover logic assumed that meant the end of the year, causing early increment of the year.

---

## Changes

- Replaced manual week/year computation with ISO-based logic.
- Now shifts to **next Monday** when called on Saturday or Sunday, letting Python handle ISO week transitions.
- Uses `isocalendar()[0]` (ISO year) consistently instead of `now.year`.

---

## Testing

| Date Tested       | Expected Result | Output | Status |
|-------------------|-----------------|---------|---------|
| 2025-10-24 (Fri)  | (43, 2025)      | ✅      | ✅ |
| 2025-10-25 (Sat)  | (44, 2025)      | ✅      | ✅ |
| 2025-10-26 (Sun)  | (44, 2025)      | ✅      | ✅ |
| 2025-12-27 (Sat)  | (1, 2026)       | ✅      | ✅ |

---

## Example

```python
import datetime

def get_current_week_and_year():
    now = datetime.datetime.now()

    # If today is Saturday or Sunday, shift to next Monday
    if now.weekday() in [5, 6]:
        days_until_monday = 7 - now.weekday()
        next_monday = now + datetime.timedelta(days=days_until_monday)
        iso_info = next_monday.isocalendar()
    else:
        iso_info = now.isocalendar()

    # iso_info = (ISO_year, ISO_week, ISO_weekday)
    return iso_info[1], iso_info[0]
