### PR TITLE
fix utc time in streamlit cloud

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,10 @@ from supabase import create_client, Client
 import hashlib
 import pandas as pd
 import datetime
+import pendulum
 
+# Définir le fuseau horaire
+tz = pendulum.timezone("Europe/Paris")
 # -------------------------
 # Config graphique
 # -------------------------
@@ -98,7 +101,7 @@ def is_bank_holiday_fr(date):
 
 
 def get_current_week_and_year():
-    now = datetime.datetime.now()
+    now = pendulum.now(tz)
 
     # If today is Saturday or Sunday, shift to next Monday
     if now.weekday() in [5, 6]:
@@ -133,7 +136,7 @@ def login_user(email, password):
     return False
 
 def is_reservation_allowed(weekday, start_time):
-    now = datetime.datetime.now()
+    now = pendulum.now(tz)
     current_weekday = now.weekday()  # 0 = Monday, 6 = Sunday
 
     # print(f"DEBUG: weekday = {weekday}, current_weekday = {current_weekday}")
@@ -217,7 +220,7 @@ def user_view(user):
 
                     with st.form(f"res_{slot['id']}"):
                         if already:
-                            current_weekday = datetime.datetime.now().weekday()
+                            current_weekday = pendulum.now(tz).weekday()
                             is_past_day = idx < current_weekday
                             # print(f"DEBUG Cancel: idx={idx}, current_weekday={current_weekday}, is_past_day={is_past_day}")
 


### PR DESCRIPTION
# 🕒 Harmonisation du fuseau horaire entre local et Streamlit Cloud
## 📌 Contexte

- L’application affichait un fuseau horaire différent selon l’environnement :
- En local, elle utilisait le fuseau de la machine (Europe/Paris).
- Sur Streamlit Cloud, elle fonctionnait en UTC par défaut.
- Cela provoquait un décalage d’une ou deux heures dans les timestamps affichés ou calculés.

## 🎯 Objectif

Garantir que l’application utilise systématiquement le fuseau horaire Europe/Paris, quel que soit l’environnement d’exécution.

## 🔧 Changements apportés

- Intégration de Pendulum pour gérer les fuseaux horaires.
- Forçage explicite du fuseau horaire via pendulum.timezone("Europe/Paris").
- Remplacement de datetime.now() par pendulum.now(tz) afin d'obtenir systématiquement la bonne heure.

## 📝 Exemple ajouté / modifié
```
import pendulum

tz = pendulum.timezone("Europe/Paris")
now = pendulum.now(tz)

st.write(now)
```

## ✅ Résultat

L’heure affichée dans l’application est désormais uniforme, fiable, et indépendante du fuseau horaire du serveur Streamlit Cloud.

## 🚀 Impact

- Amélioration de la cohérence entre local et production
- Réduction des erreurs liées aux heures
- Meilleure lisibilité des données temporelles